### PR TITLE
fix: Add amd64 nodeSelector

### DIFF
--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -23,6 +23,9 @@ spec:
         # Required for AWS IAM Role bindings
         # https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html
         fsGroup: 1337
+      nodeSelector:
+        kubernetes.io/os: linux
+        kubernetes.io/arch: amd64
       containers:
       - name: manager
         image: public.ecr.aws/aws-cloudformation/aws-cloudformation-controller-for-flux


### PR DESCRIPTION
*Issue #, if available:* 
#32 

*Description of changes:*
Force the controller onto amd64 instances. This should be removed when the controller adds arm64 support.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
