### PR TITLE
fix(ci): Only run Integ Test once per PR label event/open w/ label

### DIFF
--- a/.github/workflows/integ-tests-pr.yml
+++ b/.github/workflows/integ-tests-pr.yml
@@ -2,7 +2,7 @@ name: Pull Request Integ Tests
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, labeled]
     branches: [main]
   workflow_dispatch: {}
 


### PR DESCRIPTION
*Description of changes:*

The workflow runs on `pull_request_target` and checks out + runs code from the PR. Since the workflow runs on other events, someone could open a legitimate PR, have it labeled `safe-to-test`, and then push an update with malicious code. This change will restrict the setting, so maintainers must remove and re-add the safe-to-test label to re-run tests if someone updates code in their fork.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
